### PR TITLE
Copy missing FlashRuntimeExtensions.h

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="Air Native Extension Build Scripts" default="all">
-	
+
 	<property file="build.config"/>
 
 	<!-- Load ant-contrib -->
@@ -14,6 +14,9 @@
 
 	<!-- iOS -->
 	<target name="ios" description="Build iOS Library">
+
+		<!-- Copy FlashRuntimeExtensions.h from AIR SDK -->
+		<copy file="${air.sdk.home}/include/FlashRuntimeExtensions.h" tofile="../ios/FlashRuntimeExtensions.h" overwrite="true"/>
 
 		<!-- make the build directory for the objc code -->
 		<mkdir dir="temp/ios"/>


### PR DESCRIPTION
`FlashRuntimeExtensions.h` isn't distributed with the repo and needs to be copied from the AIR SDK before building. This PR adds a `<copy>` step to the `ios` target, ensuring it exists.