### PR TITLE
Add `GKAchievement.resetAchievements` binding

### DIFF
--- a/actionscript/src/com/freshplanet/ane/AirGameCenter/AirGameCenter.as
+++ b/actionscript/src/com/freshplanet/ane/AirGameCenter/AirGameCenter.as
@@ -151,6 +151,12 @@ import flash.events.EventDispatcher;
 				_context.call("reportAchievement", achievementId, showCompletionBanner, percentComplete);
 		}
 
+		public function resetAchievements() : void
+		{
+			if(isSupported)
+				_context.call("resetAchievements");
+		}
+
 		/**
 		 * A recent player is someone that you have played a game with or is a legacy game center friend.
 		 */
@@ -251,6 +257,12 @@ import flash.events.EventDispatcher;
 			}
 			else if (event.code == AirGameCenterEvent.ACHIEVEMENT_REPORT_FAILED) {
 				this.dispatchEvent(new AirGameCenterEvent(AirGameCenterEvent.ACHIEVEMENT_REPORT_FAILED, event.level));
+			}
+			else if (event.code == AirGameCenterEvent.ACHIEVEMENTS_RESET) {
+				this.dispatchEvent(new AirGameCenterEvent(AirGameCenterEvent.ACHIEVEMENTS_RESET));
+			}
+			else if (event.code == AirGameCenterEvent.ACHIEVEMENTS_RESET_FAILED) {
+				this.dispatchEvent(new AirGameCenterEvent(AirGameCenterEvent.ACHIEVEMENTS_RESET_FAILED, event.level));
 			}
 			else if (event.code == AirGameCenterRecentPlayersEvent.LOAD_COMPLETE) {
 				var players:Vector.<AirGameCenterPlayer> = parseRecentPlayersJSON(event.level);

--- a/actionscript/src/com/freshplanet/ane/AirGameCenter/events/AirGameCenterEvent.as
+++ b/actionscript/src/com/freshplanet/ane/AirGameCenter/events/AirGameCenterEvent.as
@@ -27,6 +27,9 @@ public class AirGameCenterEvent extends Event {
 	public static const ACHIEVEMENT_REPORTED:String = "AirGameCenterEvent_achievementReported";
 	public static const ACHIEVEMENT_REPORT_FAILED:String = "AirGameCenterEvent_achievementReportFailed";
 
+	public static const ACHIEVEMENTS_RESET:String = "AirGameCenterEvent_achievementsReset";
+	public static const ACHIEVEMENTS_RESET_FAILED:String = "AirGameCenterEvent_achievementsResetFailed";
+
 	private var _error:String;
 
 	public function AirGameCenterEvent(type:String, error:String = null, bubbles:Boolean = false, cancelable:Boolean = false) {

--- a/ios/AirGameCenter/AirGameCenter.m
+++ b/ios/AirGameCenter/AirGameCenter.m
@@ -486,6 +486,29 @@ DEFINE_ANE_FUNCTION(reportAchievement) {
     return nil;
 }
 
+DEFINE_ANE_FUNCTION(resetAchievements) {
+    
+    AirGameCenter* controller = GetAirGameCenterContextNativeData(context);
+    
+    if (!controller)
+        return AirGameCenter_FPANE_CreateError(@"context's AirGameCenter is null", 0);
+    
+    @try {
+        [GKAchievement resetAchievementsWithCompletionHandler:^(NSError * _Nullable error) {
+            if (error != nil) {
+                [controller sendEvent:kAirGameCenterEvent_achievementsResetFailed level:error.localizedDescription];
+            } else {
+                [controller sendEvent:kAirGameCenterEvent_achievementsReset];
+            }
+        }];
+    }
+    @catch (NSException *exception) {
+        [controller sendLog:[@"Exception occurred while trying to resetAchievements: " stringByAppendingString:exception.reason]];
+    }
+    
+    return nil;
+}
+
 DEFINE_ANE_FUNCTION(loadRecentPlayers) {
     
     AirGameCenter* controller = GetAirGameCenterContextNativeData(context);
@@ -589,6 +612,7 @@ void AirGameCenterContextInitializer(void* extData, const uint8_t* ctxType, FREC
         MAP_FUNCTION(showAchievements, NULL),
         MAP_FUNCTION(loadAchievements, NULL),
         MAP_FUNCTION(reportAchievement, NULL),
+        MAP_FUNCTION(resetAchievements, NULL),
         MAP_FUNCTION(loadRecentPlayers, NULL),
         MAP_FUNCTION(loadPlayerPhoto, NULL),
     };

--- a/ios/AirGameCenter/Constants.h
+++ b/ios/AirGameCenter/Constants.h
@@ -25,6 +25,8 @@ static NSString *const kAirGameCenterEvent_scoreReported = @"AirGameCenterEvent_
 static NSString *const kAirGameCenterEvent_scoreReportFailed = @"AirGameCenterEvent_scoreReportFailed";
 static NSString *const kAirGameCenterEvent_achievementReported = @"AirGameCenterEvent_achievementReported";
 static NSString *const kAirGameCenterEvent_achievementReportFailed = @"AirGameCenterEvent_achievementReportFailed";
+static NSString *const kAirGameCenterEvent_achievementsReset = @"AirGameCenterEvent_achievementsReset";
+static NSString *const kAirGameCenterEvent_achievementsResetFailed = @"AirGameCenterEvent_achievementsResetFailed";
 
 static NSString *const kAirGameCenterPhotoEvent_photoLoadError = @"AirGameCenterPhotoEvent_photoLoadError";
 


### PR DESCRIPTION
Adds `AirGameCenter.resetAchievements`, which calls through to `[GKAchievement resetAchievements]` on iOS (and dispatches success/failure events).